### PR TITLE
Fixes Zen Tidy Downloads preferences to be compatible with Sine.

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -45,14 +45,16 @@
   },
   {
     "property": "extensions.downloads.progress_update_throttle_ms",
-    "type": "number",
+    "type": "string",
+    "value": "number",
     "label": "Throttle delay for in-progress download updates (ms)",
-    "defaultValue": 500
+    "default": 500
   },
   {
     "property": "extensions.downloads.show_old_downloads_hours",
-    "type": "number",
+    "type": "string",
+    "value": "number",
     "label": "Show old completed downloads on startup (hours)",
-    "defaultValue": 2
+    "default": 2
   }
 ] 


### PR DESCRIPTION
Currently Zen-Tidy-Downloads includes a type of number which is not supported. As a substitute, Sine provides a value property which I have set to number.